### PR TITLE
Fix register omitting -allow causing 400 invalid_allowfrom_cidr

### DIFF
--- a/pkg/client/register.go
+++ b/pkg/client/register.go
@@ -84,7 +84,10 @@ func (c *AcmednsClient) Register() {
 		PrintWarning(fmt.Sprintf("Acme-dns account already registered for domain %s", c.Config.Domain), 0)
 	} else {
 		// register a new account
-		allowFrom := strings.Split(c.Config.AllowList, ",")
+		allowFrom := []string{}
+		if c.Config.AllowList != "" {
+			allowFrom = strings.Split(c.Config.AllowList, ",")
+		}
 		c.Debug("Registering new account with the acme-dns server")
 		newAccount, err := client.RegisterAccount(allowFrom)
 		if err != nil {


### PR DESCRIPTION
If you attempt to register to joohoi/acme-dns server without specifying an allow flag, the request sent to the server is an array containing the empty string `[""]`, which responds with 400 `invalid_allowfrom_cidr`. Instead, this fix makes omitting allow send an empty array `[]` which allows registration to work correctly.