### PR TITLE
Exit successfully if certbot renew validation is successful

### DIFF
--- a/main.go
+++ b/main.go
@@ -66,6 +66,8 @@ func main() {
 			UsageGeneric()
 			os.Exit(1)
 		}
+		// Successfully validated
+		os.Exit(0)
 	}
 
 	switch os.Args[1] {


### PR DESCRIPTION
When certbot renew is run, acme-dns-client is called with 0 arguments. When validation for this passes, it doesn't exit with code 0. Instead it continues on, causing "index out of range [1]". This fix exits with 0 so that it doesn't throw later.