### PR TITLE
breaking: move storage dir to `/etc/acme-dns-client`

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	storagepath = "/etc/acmedns/clientstorage.json"
+	storagepath = "/etc/acme-dns-client/clientstorage.json"
 	VERSION     = "0.3"
 )
 


### PR DESCRIPTION
Fixes #11.

User must move storage from `/etc/acmedns` to `/etc/acme-dns-client` manually.